### PR TITLE
fix(ci): disable Husky in release workflow

### DIFF
--- a/.github/workflows/.release.yml
+++ b/.github/workflows/.release.yml
@@ -26,8 +26,11 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
       - run: npm ci
+        env:
+          HUSKY: 0
       - run: npx semantic-release # semantic-release includes npm run prepack
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          HUSKY: 0


### PR DESCRIPTION
Set HUSKY=0 during npm ci and semantic-release; optional CI early-exit in Husky. Keeps hooks for devs, unblocks release commit.