### PR TITLE
fix: rename package to @felixfelix/play-tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
-  "name": "play-tool",
+  "name": "@felixfelix/play-tool",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0-development",
   "description": "",
   "type": "module",


### PR DESCRIPTION
npm rejected 'play-tool' as too similar to 'playtool'. Switch to a scoped public package.