### PR TITLE
ci: remove self-approval step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,6 @@ jobs:
             package-lock.json
             CHANGELOG.md
 
-      # approve via GitHub CLI (preinstalled)
-      - name: Approve sync PR
-        if: steps.cpr.outputs.pull-request-operation != 'none'
-        run: gh pr review --approve ${{ steps.cpr.outputs.pull-request-number }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       # enable auto-merge; requires repo setting “Allow auto-merge”
       - name: Enable auto-merge for sync PR
         if: steps.cpr.outputs.pull-request-operation != 'none'


### PR DESCRIPTION
Removes the GitHub Actions self-approval step, since Actions cannot approve their own PRs. Auto-merge still applies once checks pass.