### PR TITLE
chore: move play function into its own file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,1 @@
-export const play =
-  (...actions) =>
-  async (input = {}) => {
-    let current = input
-
-    for (const action of actions) {
-      current = await action(current)
-    }
-
-    return current
-  }
+export { play } from './play.js'

--- a/src/play.js
+++ b/src/play.js
@@ -1,0 +1,11 @@
+export const play =
+  (...actions) =>
+  async (input = {}) => {
+    let current = input
+
+    for (const action of actions) {
+      current = await action(current)
+    }
+
+    return current
+  }

--- a/src/play.test.js
+++ b/src/play.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { play } from './index'
+import { play } from './play'
 
 describe('success', () => {
   it('returns an object', async () => {


### PR DESCRIPTION
## Summary
This PR moves the `play` function implementation into a dedicated `play.js` file.

## Details
- Extracted `play` from `index.js` into `play.js`
- `index.js` now re-exports `play` from `play.js`
- No logic changes were introduced
- Tests have been updated to import `isPlainObject` from `play.js`

## Why
This improves code organization by isolating the core logic into its own file, while keeping the public API unchanged.
Consumers still import `play` from the package root.