### PR TITLE
chore(release): v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [0.3.8](https://github.com/xifeleltouma/play-tool-js/compare/v0.3.7...v0.3.8) (2025-09-18)
+
+### Bug Fixes
+
+- trigger release ([#39](https://github.com/xifeleltouma/play-tool-js/issues/39)) ([3d38090](https://github.com/xifeleltouma/play-tool-js/commit/3d38090741171c2d403144c738272a56bb5da700))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@felixfelix/play-tool",
-  "version": "0.0.0-development",
+  "version": "0.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@felixfelix/play-tool",
-      "version": "0.0.0-development",
+      "version": "0.3.8",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^9.35.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.0-development",
+  "version": "0.3.8",
   "description": "A tiny async pipeline helper for composing steps that share a context.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Files generated by semantic-release (version bump & changelog).

### Release notes for v0.3.8

## [0.3.8](https://github.com/xifeleltouma/play-tool-js/compare/v0.3.7...v0.3.8) (2025-09-18)


### Bug Fixes

* trigger release ([#39](https://github.com/xifeleltouma/play-tool-js/issues/39)) ([3d38090](https://github.com/xifeleltouma/play-tool-js/commit/3d38090741171c2d403144c738272a56bb5da700))